### PR TITLE
[feat] Support faiss-1.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ include_directories(${OpenBLAS_INCLUDE_DIR})
 set(BLAS_LIB ${OpenBLAS_LIB})
 
 #external libraries like faiss
-include_directories(${PROJECT_SOURCE_DIR}/extern_libraries)
-link_directories(${PROJECT_SOURCE_DIR}/extern_libraries/faiss/lib)
+include_directories(${PROJECT_SOURCE_DIR}/extern_libraries/faiss)
+link_directories(${PROJECT_SOURCE_DIR}/extern_libraries/faiss/build/faiss)
 
 add_definitions (-std=c++11 -O3 -lboost -march=native -Wall -DINFO)
 

--- a/src/index_pq.cpp
+++ b/src/index_pq.cpp
@@ -5,9 +5,11 @@
 #include <efanna2e/exceptions.h>
 #include <efanna2e/parameters.h>
 #include <faiss/index_io.h>
+#include <faiss/index_factory.h>
 #include <omp.h>
 
 namespace efanna2e {
+
 IndexPQ::IndexPQ(const size_t dimension, const size_t n, Metric m, Index *initializer):Index(dimension, n, m),
      initializer_{initializer}{}
 
@@ -59,7 +61,7 @@ void IndexPQ::Build(size_t n, const float *data, const Parameters &parameters) {
   }
 
   unsigned k = 10;
-  faiss::Index::idx_t *gt = new faiss::Index::idx_t[k * sample_num];//ground truth
+  faiss::idx_t *gt = new faiss::idx_t[k * sample_num];//ground truth
   unsigned * gt_c = new unsigned[k * sample_num];
   compute_gt_for_tune(sample_queries, sample_num, k, gt_c);
   for(unsigned i=0; i<k*sample_num; i++){
@@ -99,7 +101,7 @@ void IndexPQ::Search(
   faiss::ParameterSpace f_params;
   f_params.set_index_parameters(index, search_key.c_str());
 
-  faiss::Index::idx_t *Ids = new faiss::Index::idx_t[k];
+  faiss::idx_t *Ids = new faiss::idx_t[k];
   float *Dists = new float[k];
 
   index->search(1, query, k, Dists, Ids);


### PR DESCRIPTION
Due to API changes in Faiss, the newer versions require certain modifications to run. In index_pq.cpp, the header file `<faiss/index_factory.h>` needs to be added, and `faiss::Index::idx_t` should be changed to `faiss::idx_t`. Additionally, Faiss does not directly include `lib` directory, which relates to the specific compilation method. According to the current compilation process for version 1.12.0, the `.a` static files will be obtained in `build/faiss`. 

However, the issue is that I have not been able to determine exactly which version of Faiss introduced these changes. The `README` only recommends using Faiss, so the original version used is also unknown. If possible, I would like to submit this as a feature branch supporting `Faiss-v1.12.0`, or add an explanation in the `README`.